### PR TITLE
inn-service.yml: Run all pynntp tests

### DIFF
--- a/.github/workflows/inn-service.yml
+++ b/.github/workflows/inn-service.yml
@@ -15,10 +15,14 @@ jobs:
           - 119:119
           - 563:563
     steps:
-      - run: pip install --user pynntp
-      - shell: python
-        run: |
-            import nntp
-            nntp_client = nntp.NNTPClient("localhost")
-            print(f"{tuple(nntp_client.list_newsgroups()) = }")
-            nntp_client.quit()
+      # Run all pynntp tests
+      - uses: actions/checkout@v4
+        with:
+          repository: greenbender/pynntp
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install --upgrade pip
+      - run: pip install pytest
+      - run: pip install --editable .
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ```
 docker build -t inn .
-docker run --rm -t -p119:119 inn
+docker run --rm -t -p119:119 -p563:563 inn
 ```
 To use this in a GitHub Action please add:
 ```yaml


### PR DESCRIPTION
Ensure the full `pynntp` test suite passes on the `inn-docker` service.

This could be run manually (`workflow_dispatch`) after a deployment to DockerHub.  Or perhaps this could be run after each new release has landed on DockerHub (`needs: push_to_registries`).