### PR TITLE
Cannot sync news between two Docker-based INN servers

### DIFF
--- a/two_containers/README.md
+++ b/two_containers/README.md
@@ -1,0 +1,32 @@
+# Can we sync news between two Docker-based INN servers?
+
+Get two Docker-based INN servers up and running.
+```sh
+docker compose up --build
+```
+You can log into the containers in ___separate terminal tabs___ with:
+```sh
+docker exec -it inn-server-a sh
+docker exec -it inn-server-b sh
+```
+Ensure that the Docker network allows bidirectional communications.
+```sh
+docker exec -it inn-server-a ping -c 2 inn-server-b
+docker exec -it inn-server-b ping -c 2 inn-server-a
+```
+Add config to the end of `etc/incoming.conf` and `etc/newsfeeds`.
+Create a `my.public` newsgroup and tail key files.
+Run `ctlinnd reload '' 'Reload configuration files'`
+```sh
+docker exec -it inn-server-a /inn_config/create_newsgroups.sh
+docker exec -it inn-server-b /inn_config/create_newsgroups.sh
+```
+Add a few news articles to inn-server-a newsgroups and verify their presence with:
+```sh
+docker exec -it inn-server-a cat db/active
+```
+Check to see if the articles have been synced over to inn-server-b.
+```sh
+docker exec -it inn-server-b cat db/active
+```sh
+## ___Unfortunately___ the articles are never synced between the two servers.

--- a/two_containers/README.md
+++ b/two_containers/README.md
@@ -14,7 +14,7 @@ Ensure that the Docker network allows bidirectional communications.
 docker exec -it inn-server-a ping -c 2 inn-server-b
 docker exec -it inn-server-b ping -c 2 inn-server-a
 ```
-Add config to the end of `etc/incoming.conf` and `etc/newsfeeds`.
+Add config to the end of `etc/incoming.conf`, `etc/innfeed.conf`, and `etc/newsfeeds`.
 Create a `my.public` newsgroup and tail key files.
 Run `ctlinnd reload '' 'Reload configuration files'`
 ```sh
@@ -28,5 +28,13 @@ docker exec -it inn-server-a cat db/active
 Check to see if the articles have been synced over to inn-server-b.
 ```sh
 docker exec -it inn-server-b cat db/active
+```
+This will say that the config file is OK.
 ```sh
+docker exec -it inn-server-a innfeed -C
+```
+This will generate a Segmentation fault!
+```sh
+docker exec -it inn-server-a innfeed
+```
 ## ___Unfortunately___ the articles are never synced between the two servers.

--- a/two_containers/docker-compose.yml
+++ b/two_containers/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  inn-server-a:
+    image: greenbender/inn
+    hostname: inn-server-a
+    container_name: inn-server-a
+    ports:
+      - "119:119"
+      - "563:563"
+    volumes:
+      - ./inn_config:/inn_config
+
+  inn-server-b:
+    image: greenbender/inn
+    hostname: inn-server-b
+    container_name: inn-server-b
+    ports:
+      - "1119:119"
+      - "1563:563"
+    volumes:
+      - ./inn_config:/inn_config

--- a/two_containers/inn_config/create_newsgroups.sh
+++ b/two_containers/inn_config/create_newsgroups.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# $HOSTNAME should be "inn-server-a" or "inn-server-b"
+echo $HOSTNAME
+
+cat /inn_config/$HOSTNAME/etc_incoming.conf >> etc/incoming.conf
+cat /inn_config/$HOSTNAME/etc_innfeed.conf >> etc/innfeed.conf
+cat /inn_config/$HOSTNAME/etc_newsfeeds >> etc/newsfeeds
+
+ctlinnd newgroup my.public
+tail etc/incoming.conf etc/innfeed.conf etc/newsfeeds db/active
+
+ctlinnd reload '' 'Reload configuration files'
+innfeed -C
+# innfeed  # --> Segmentation fault

--- a/two_containers/inn_config/inn-server-a/etc_incoming.conf
+++ b/two_containers/inn_config/inn-server-a/etc_incoming.conf
@@ -1,0 +1,7 @@
+
+peer inn-server-b {
+    ip-name: inn-server-b
+    port-number: 119
+    max-connections: 1
+    streaming: true
+}

--- a/two_containers/inn_config/inn-server-a/etc_innfeed.conf
+++ b/two_containers/inn_config/inn-server-a/etc_innfeed.conf
@@ -1,0 +1,18 @@
+
+peer inn-server-b {
+    ip-name: inn-server-b
+    port: 119
+    max-connections: 5
+    dynamic-method: combined
+    username: "innfeed"
+    password: "password"  # Use actual password if authentication is configured
+    streaming: true
+    max-stream-articles: 10
+    article-timeout: 600
+    initial-connections: 2
+    min-queue-connection: 25
+    max-queue-connection: 100
+    no-check-high: true
+    no-trust-deferred: false
+    drop-deferred: false
+}

--- a/two_containers/inn_config/inn-server-a/etc_newsfeeds
+++ b/two_containers/inn_config/inn-server-a/etc_newsfeeds
@@ -1,0 +1,4 @@
+
+inn-server-b\
+    :*\
+    :Tf,Wnm:

--- a/two_containers/inn_config/inn-server-b/etc_incoming.conf
+++ b/two_containers/inn_config/inn-server-b/etc_incoming.conf
@@ -1,0 +1,7 @@
+
+peer inn-server-a {
+    ip-name: inn-server-a
+    port-number: 119
+    max-connections: 1
+    streaming: true
+}

--- a/two_containers/inn_config/inn-server-b/etc_innfeed.conf
+++ b/two_containers/inn_config/inn-server-b/etc_innfeed.conf
@@ -1,0 +1,18 @@
+
+peer inn-server-a {
+    ip-name: inn-server-a
+    port: 119
+    max-connections: 5
+    dynamic-method: combined
+    username: "innfeed"
+    password: "password"  # Use actual password if authentication is configured
+    streaming: true
+    max-stream-articles: 10
+    article-timeout: 600
+    initial-connections: 2
+    min-queue-connection: 25
+    max-queue-connection: 100
+    no-check-high: true
+    no-trust-deferred: false
+    drop-deferred: false
+}

--- a/two_containers/inn_config/inn-server-b/etc_newsfeeds
+++ b/two_containers/inn_config/inn-server-b/etc_newsfeeds
@@ -1,0 +1,4 @@
+
+inn-server-a\
+    :*\
+    :Tf,Wnm:


### PR DESCRIPTION
```
└── two_containers
    ├── docker-compose.yml
    ├── inn_config
    │   ├── create_newsgroups.sh
    │   ├── inn-server-a
    │   │   ├── etc_incoming.conf
    │   │   ├── etc_innfeed.conf
    │   │   └── etc_newsfeeds
    │   └── inn-server-b
    │       ├── etc_incoming.conf
    │       ├── etc_innfeed.conf
    │       └── etc_newsfeeds
    └── README.md
```
# Can we sync news between two Docker-based INN servers?

Get two Docker-based INN servers up and running.
% `cd two_containers`
% `docker compose up --build`

You can log into the containers in ___separate terminal tabs___ with:
% `docker exec -it inn-server-a sh`
% `docker exec -it inn-server-b sh`

Ensure that the Docker network allows bidirectional communications.
% `docker exec -it inn-server-a ping -c 2 inn-server-b`
% `docker exec -it inn-server-b ping -c 2 inn-server-a`

Add config to the end of `etc/incoming.conf`, `etc/innfeed.conf`, and `etc/newsfeeds`.
Create a `my.public` newsgroup and tail key files.
Run `ctlinnd reload '' 'Reload configuration files'`
% `docker exec -it inn-server-a /inn_config/create_newsgroups.sh`
% `docker exec -it inn-server-b /inn_config/create_newsgroups.sh`

Add a few news articles to inn-server-a newsgroups and verify their presence with:
% `docker exec -it inn-server-a cat db/active`

Check to see if the articles have been synced over to inn-server-b.
% `docker exec -it inn-server-b cat db/active`

This will say that the config file is OK.
% `docker exec -it inn-server-a innfeed -C`

This will generate a Segmentation fault!
% `docker exec -it inn-server-a innfeed`

## ___Unfortunately___ the articles are never synced between the two servers.